### PR TITLE
Adding version ethers@^5.6.9 in dependencies indication to avoid ethers V6 breaking changes

### DIFF
--- a/developer-tooling/push-sdk/epns-sdk-starter-kit.md
+++ b/developer-tooling/push-sdk/epns-sdk-starter-kit.md
@@ -46,9 +46,9 @@ yarn add styled-components
 ```
 
 2\. Since its a dapp, the following are the **web3** dependencies that you can install for wallet connection
-
+**version of Ethers (v6) introduces some breaking changes, for best results use Ethers v5 (ethers@^5.6)**
 ```
- yarn add ethers
+yarn add ethers@5.6.9
 ```
 
 3\.  The next package might only be needed if you are using web3-react. _You are free to use any other React-based web3 solution._


### PR DESCRIPTION
Adding note (and version) to people following dependencies intallation to install version ethers@^5.6.9 to avoid ethers V6 breaking changes, this according to what tells the docs [here](https://docs.push.org/developers/developer-tooling/push-sdk/sdk-packages-details/epnsproject-sdk-restapi/for-notification/opt-in-and-opt-out)

![Screenshot from 2023-04-22 11-15-59](https://user-images.githubusercontent.com/23249805/233800513-d8c340de-dc23-40d5-bbf2-2a12cf6dfb43.png)
